### PR TITLE
fix(versioning): get git tag sort by creation date

### DIFF
--- a/swebench/versioning/get_versions_c.py
+++ b/swebench/versioning/get_versions_c.py
@@ -33,7 +33,7 @@ def get_version(instance)->Optional[str]:
     """
     repo = instance["repo"]
     out_check = subprocess.run(
-        f"git tag --no-contains {instance['base_commit']}",
+        f"git tag --no-contains {instance['base_commit']} --sort=creatordate",
         shell=True,
         capture_output=True,
     )


### PR DESCRIPTION
Fix issue where all the task instances were getting same release version